### PR TITLE
farmer: use FARMER_URL for env var name

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Create database:
 
 ```sh
 createdb testbot
-psql testbot < $I10R/testbot/farmer/schema.sql
+psql testbot < ./farmer/schema.sql
 ```
 
 In a new shell, start an [ngrok](https://ngrok.com) tunnel:
@@ -25,11 +25,11 @@ with `repo` and `write:repo_hook` scopes.
 In another shell:
 
 ```
-BASE_URL=https://{{ YOUR_NGROK_TUNNEL }}.ngrok.io/ \
 DATABASE_URL=postgres:///testbot?sslmode=disable \
-GITHUB_TOKEN={{ YOUR_TOKEN }} \
+FARMER_URL=https://changeme.ngrok.io/ \
 GITHUB_ORG=wepogo \
 GITHUB_REPO=citest \
+GITHUB_TOKEN=changeme \
 HOOK_SECRET=anything \
 testbot farmer
 ```

--- a/farmer/main.go
+++ b/farmer/main.go
@@ -102,7 +102,7 @@ func or(v, d string) string {
 
 var (
 	// TODO(tmaher): move secrets into EC2 parameter store.
-	baseURLStr  = os.Getenv("BASE_URL")
+	baseURLStr  = os.Getenv("FARMER_URL")
 	dumpReqsStr = os.Getenv("DUMP")
 	dbURL       = os.Getenv("DATABASE_URL")
 	hookSecret  = os.Getenv("HOOK_SECRET")
@@ -127,7 +127,7 @@ func Main() {
 	var err error
 	baseURL, err = url.Parse(baseURLStr)
 	if err != nil {
-		log.Fatalkv(context.Background(), "variable", "BASE_URL", log.Error, err)
+		log.Fatalkv(context.Background(), "variable", "FARMER_URL", log.Error, err)
 		os.Exit(1)
 	}
 	dumpReqs, err = strconv.ParseBool(dumpReqsStr)


### PR DESCRIPTION
This matches the env var name used by `worker`,
which might be easier for users to understand.