### PR TITLE
all: remove setup special case

### DIFF
--- a/farmer/guide.go
+++ b/farmer/guide.go
@@ -67,18 +67,6 @@ directories would be /, /a, /a/b, /d, /f, /h, and /j.
 Note in particular that merely deleting a file from a
 directory will run the tests in that directory.
 
-As a special case, an entry named "setup" will not run
-as a test on its own. Instead, it will run before every
-other test in its Testfile and the Testfile in any
-parent directory. For parent-directory Testfiles, the
-setup entry runs even if no files in the setup entry's
-directory were affected. A consequence of all this is
-there can be multiple setup tasks for a single test.
-The setup tasks run in an arbitrary order; the only
-guarantee is that they run sequentially and they all
-finish before the test starts. If any setup task fails,
-the test won't be run, and is considered to have failed.
-
 
 Test Environment
 

--- a/farmer/job.go
+++ b/farmer/job.go
@@ -91,11 +91,6 @@ func populateJobsBG(sha string, files []string) {
 		}
 		var names []string
 		for name := range entries {
-			// Note: "setup" has special meaning and is handled in `worker/main.go`
-			// recursively for all the directories *before* each test is run.
-			if name == "setup" {
-				continue
-			}
 			names = append(names, name)
 		}
 		err = upsertJobs(ctx, sha, dir, names)


### PR DESCRIPTION
When in use, this `setup` special case is hard to reason about.
Remove it to lower cognitive overhead and opportunity for bugs.