### PR TITLE
farmer: fix results section of UI

### DIFF
--- a/farmer/main.go
+++ b/farmer/main.go
@@ -101,7 +101,6 @@ func or(v, d string) string {
 }
 
 var (
-	// TODO(tmaher): move secrets into EC2 parameter store.
 	baseURLStr  = os.Getenv("FARMER_URL")
 	dumpReqsStr = os.Getenv("DUMP")
 	dbURL       = os.Getenv("DATABASE_URL")
@@ -349,8 +348,6 @@ func live(w http.ResponseWriter, req *http.Request) {
 	data := struct {
 		Title string
 		PR    []int64
-		Org   string
-		Repo  string
 		Live  bool
 
 		Results   []resultInfo
@@ -358,8 +355,6 @@ func live(w http.ResponseWriter, req *http.Request) {
 	}{
 		Title: fmt.Sprintf("%.8s %s %s", job.SHA, job.Dir, job.Name),
 		PR:    pr,
-		Org:   org,
-		Repo:  repo,
 		Live:  isLive,
 	}
 

--- a/farmer/state.go
+++ b/farmer/state.go
@@ -267,13 +267,14 @@ func listJobs(ctx context.Context) (j []testbot.Job, err error) {
 }
 
 type resultInfo struct {
-	BaseURL   string
 	ID        int
 	SHA       string
 	Dir       string
 	Name      string
 	ElapsedMS int
 	ElapsedSp string // for display
+	Org       string
+	Repo      string
 	PR        []int64
 	State     string
 	Desc      string
@@ -323,7 +324,8 @@ func scanResults(rows *sql.Rows, err error) ([]resultInfo, error) {
 			return nil, err
 		}
 		result.ElapsedSp = pad(strconv.Itoa(result.ElapsedMS))
-		result.BaseURL = baseURLStr
+		result.Org = org
+		result.Repo = repo
 		res = append(res, result)
 	}
 	return res, rows.Err()

--- a/farmer/ui.go
+++ b/farmer/ui.go
@@ -20,18 +20,22 @@ var page = template.Must(template.New("page").Funcs(funcMap).Parse(`
   title={{.CreatedAt.Local.Format "2006-01-02T15:04:05.000Z07:00"}}
 >
 {{- reltime .CreatedAt | printf "%8s" -}}
-</time> <a href={{.BaseURL}}/result/{{.ID}}>{{.ID}}</a>
+</time> <a href=/result/{{.ID}}>result</a>
 {{- .ElapsedSp}} {{.ElapsedMS}}ms
-{{- if eq .State "success"}} ok   {{else}} <b>fail</b> {{end -}}
+{{- if eq .State "success"}} ok {{else}} <b>fail</b> {{end -}}
+{{- $org := .Org }}
+{{- $repo := .Repo }}
 {{- range .PR -}}
-<a href=https://github.com/{{$.Org}}/{{$.Repo}}/pull/{{.}}>{{.}}</a> {{end -}}
+<a href=https://github.com/{{$org}}/{{$repo}}/pull/{{.}}>#{{.}}</a> {{end -}}
 {{- printf "%.8s" .SHA}} {{.Dir}} {{.Name -}}
 {{- if eq .State "success"}}{{else}} <b>{{.Desc}}</b>{{end -}}
 {{- end -}}
 
 {{- define "prlist" -}}
+{{- $org := .Org }}
+{{- $repo := .Repo }}
 {{range .PR -}}
-<a href="https://github.com/{{$.Org}}/{{$.Repo}}/pull/{{.}}">https://github.com/{{$.Org}}/{{$.Repo}}/pull/{{.}}</a>
+<a href="https://github.com/{{$org}}/{{$repo}}/pull/{{.}}">https://github.com/{{$org}}/{{$repo}}/pull/{{.}}</a>
 {{end}}
 {{- end -}}
 


### PR DESCRIPTION
We don't need to pass a URL from out of the environment
because it's relative to the view the page is served on.