### PR TITLE
all: remove references to old env vars

### DIFF
--- a/cmd/testbot/main.go
+++ b/cmd/testbot/main.go
@@ -39,12 +39,12 @@ const usageString = `usage:
   testbot worker
   testbot onejob [sha] [dir] [name]
 
-For onejob, sha is a git commit hash, dir is the location
-of a Testfile relative to $I10R, and name is the name
-of an entry in the Testfile.
+For onejob, sha is a Git commit hash,
+dir is the path to a Testfile relative to repo root,
+and name is the name of an entry in the Testfile.
 
 Example:
-  $ testbot onejob e3e9378da testbot gotest
+  $ testbot onejob e3e9378da subdir gotest
 `
 
 var needArgs = map[string]int{"farmer": 2, "worker": 2, "onejob": 5}

--- a/worker/main.go
+++ b/worker/main.go
@@ -324,7 +324,6 @@ func startJob(job testbot.Job) func() {
 		f.Seek(0, 0)
 		if s := scanError(f); s != "" && status != "success" {
 			s = strings.Replace(s, cmddir+"/", "", -1)
-			s = strings.Replace(s, repoDir+"/", "$I10R/", -1)
 			desc += ": " + s
 		}
 		f.Seek(0, 0)
@@ -411,10 +410,7 @@ func startJobProc(ctx context.Context, w io.Writer, job testbot.Job) (*exec.Cmd,
 func prepareCommand(ctx context.Context, dir string, w io.Writer, cmd string) *exec.Cmd {
 	c := command(ctx, w, "/bin/bash", "-eo", "pipefail", "-c", cmd)
 	c.Env = append(os.Environ(),
-		"CHAIN="+repoDir,
-		"I10R="+repoDir,
 		"GOBIN="+binDir,
-		"NETLIFY_AUTH_TOKEN="+netlify,
 		"PATH="+binDir+":"+repoDir+"/bin:"+os.Getenv("PATH"),
 	)
 	c.Dir = dir


### PR DESCRIPTION
These variables can be read from the environment itself,
don't need to be special-cased.

https://github.com/wepogo/testbot/issues/15